### PR TITLE
fix: validate Arc connection at startup

### DIFF
--- a/cmd/memtrace/main.go
+++ b/cmd/memtrace/main.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/Basekick-Labs/memtrace/internal/agent"
 	"github.com/Basekick-Labs/memtrace/internal/api"
@@ -59,6 +61,14 @@ func main() {
 		cfg.Arc.QueryTimeout,
 		logger,
 	)
+
+	// Verify Arc connectivity
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := arcCli.Ping(ctx); err != nil {
+		logger.Fatal().Err(err).Str("arc_url", cfg.Arc.URL).Msg("Failed to connect to Arc")
+	}
+	logger.Info().Str("arc_url", cfg.Arc.URL).Msg("Arc connection verified")
 
 	// Initialize metadata DB
 	metaDB, err := metadata.New(cfg.Auth.DBPath, logger)


### PR DESCRIPTION
## Summary
- Memtrace now calls `arcClient.Ping()` during startup with a 5-second timeout
- If Arc is unreachable, Memtrace exits immediately with a clear error message instead of starting silently and failing on first request
- Uses the existing `Ping()` method (`internal/arc/client.go:233`) which hits Arc's `/health` endpoint

## Test plan
- [x] `go build ./cmd/...` compiles
- [x] Start Memtrace with Arc running — starts normally, logs `Arc connection verified`
- [x] Start Memtrace with Arc stopped — exits with `Failed to connect to Arc`