### PR TITLE
fix: resolve 4 bugs found during live multi-agent testing

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -117,8 +117,8 @@ func (m *Manager) Get(ctx context.Context, orgID, agentID string) (*Agent, error
 
 	err := m.db.QueryRowContext(ctx, `
 		SELECT id, org_id, name, description, config_json, created_at, last_active_at
-		FROM agents WHERE id = ? AND org_id = ?
-	`, agentID, orgID).Scan(&id, &org, &name, &description, &configJSON, &createdAt, &lastActive)
+		FROM agents WHERE (id = ? OR name = ?) AND org_id = ?
+	`, agentID, agentID, orgID).Scan(&id, &org, &name, &description, &configJSON, &createdAt, &lastActive)
 
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {

--- a/internal/api/agent_handler.go
+++ b/internal/api/agent_handler.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"strings"
+
 	"github.com/Basekick-Labs/memtrace/internal/agent"
 	"github.com/Basekick-Labs/memtrace/internal/auth"
 	"github.com/Basekick-Labs/memtrace/internal/memory"
@@ -43,6 +45,11 @@ func (h *AgentHandler) handleCreate(c *fiber.Ctx) error {
 
 	a, err := h.agentManager.Create(c.Context(), orgID, &req)
 	if err != nil {
+		if strings.Contains(err.Error(), "already exists") {
+			return c.Status(fiber.StatusConflict).JSON(fiber.Map{
+				"error": err.Error(),
+			})
+		}
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"error": err.Error(),
 		})

--- a/internal/arc/client.go
+++ b/internal/arc/client.go
@@ -244,17 +244,17 @@ func (c *Client) writeColumnar(ctx context.Context, records []map[string]interfa
 	return nil
 }
 
-// QueryResponse represents a query result from Arc
-type QueryResponse struct {
-	Columns []string                 `json:"columns"`
-	Types   []string                 `json:"types"`
-	Data    []map[string]interface{} `json:"data"`
+// queryResponse represents a query result from Arc.
+// Arc returns columns as a string array and data as an array of arrays (rows of values).
+type queryResponse struct {
+	Columns []string        `json:"columns"`
+	Data    [][]interface{} `json:"data"`
 }
 
-// Query executes a SQL query against Arc and returns the results
+// Query executes a SQL query against Arc and returns the results as maps keyed by column name.
 func (c *Client) Query(ctx context.Context, sql string) ([]map[string]interface{}, error) {
 	payload := map[string]string{
-		"q": sql,
+		"sql": sql,
 	}
 
 	data, err := json.Marshal(payload)
@@ -288,17 +288,24 @@ func (c *Client) Query(ctx context.Context, sql string) ([]map[string]interface{
 		return nil, fmt.Errorf("Arc query failed (status %d): %s", resp.StatusCode, string(body))
 	}
 
-	var result QueryResponse
+	var result queryResponse
 	if err := json.Unmarshal(body, &result); err != nil {
-		// Try as array of maps (some Arc response formats)
-		var rows []map[string]interface{}
-		if err2 := json.Unmarshal(body, &rows); err2 != nil {
-			return nil, fmt.Errorf("failed to parse response: %w (body: %s)", err, string(body))
-		}
-		return rows, nil
+		return nil, fmt.Errorf("failed to parse response: %w (body: %s)", err, string(body))
 	}
 
-	return result.Data, nil
+	// Zip columns with row values to produce maps
+	rows := make([]map[string]interface{}, 0, len(result.Data))
+	for _, row := range result.Data {
+		m := make(map[string]interface{}, len(result.Columns))
+		for i, col := range result.Columns {
+			if i < len(row) {
+				m[col] = row[i]
+			}
+		}
+		rows = append(rows, m)
+	}
+
+	return rows, nil
 }
 
 // Ping checks connectivity to Arc


### PR DESCRIPTION
## Summary
- **Arc query field name**: Changed `"q"` to `"sql"` in query payload — every query since Phase 1 was silently failing (dedup fails open hid this)
- **Arc response parsing**: Handle columnar format `{columns:[], data:[[]]}` instead of expecting `[]map[string]interface{}`
- **Agent 409 Conflict**: Return HTTP 409 on duplicate agent registration so SDK can catch `ConflictError` and fall back to `get_agent(name)`
- **Agent lookup by name**: `Get()` now matches by `id OR name`, supporting SDK's `get_agent("historian")` pattern

All 4 bugs were discovered during live testing with the Super Bowl multi-agent demo (3 Claude agents sharing a Memtrace session).

## Test plan
- [x] `go build ./cmd/... ./internal/... ./pkg/...` passes
- [x] Re-run Super Bowl demo: all 3 agents register, store, and recall memories without errors
- [x] Dedup check works (re-run same agent, duplicate memories rejected)
- [x] Agent re-registration is idempotent (409 → get_agent fallback)