### PR TITLE
feat: add structured logging to API handlers

### DIFF
--- a/internal/api/agent_handler.go
+++ b/internal/api/agent_handler.go
@@ -7,19 +7,22 @@ import (
 	"github.com/Basekick-Labs/memtrace/internal/auth"
 	"github.com/Basekick-Labs/memtrace/internal/memory"
 	"github.com/gofiber/fiber/v2"
+	"github.com/rs/zerolog"
 )
 
 // AgentHandler handles agent endpoints
 type AgentHandler struct {
 	agentManager  *agent.Manager
 	memoryManager *memory.Manager
+	logger        zerolog.Logger
 }
 
 // NewAgentHandler creates a new agent handler
-func NewAgentHandler(agentManager *agent.Manager, memoryManager *memory.Manager) *AgentHandler {
+func NewAgentHandler(agentManager *agent.Manager, memoryManager *memory.Manager, logger zerolog.Logger) *AgentHandler {
 	return &AgentHandler{
 		agentManager:  agentManager,
 		memoryManager: memoryManager,
+		logger:        logger.With().Str("component", "agent-handler").Logger(),
 	}
 }
 
@@ -54,6 +57,8 @@ func (h *AgentHandler) handleCreate(c *fiber.Ctx) error {
 			"error": err.Error(),
 		})
 	}
+
+	h.logger.Info().Str("org_id", orgID).Str("agent_id", a.ID).Str("name", req.Name).Msg("Agent registered")
 
 	return c.Status(fiber.StatusCreated).JSON(a)
 }
@@ -143,6 +148,8 @@ func (h *AgentHandler) handleDelete(c *fiber.Ctx) error {
 			"error": err.Error(),
 		})
 	}
+
+	h.logger.Info().Str("org_id", orgID).Str("agent_id", agentID).Msg("Agent deleted")
 
 	return c.SendStatus(fiber.StatusNoContent)
 }

--- a/internal/api/memory_handler.go
+++ b/internal/api/memory_handler.go
@@ -4,16 +4,21 @@ import (
 	"github.com/Basekick-Labs/memtrace/internal/auth"
 	"github.com/Basekick-Labs/memtrace/internal/memory"
 	"github.com/gofiber/fiber/v2"
+	"github.com/rs/zerolog"
 )
 
 // MemoryHandler handles memory CRUD endpoints
 type MemoryHandler struct {
 	manager *memory.Manager
+	logger  zerolog.Logger
 }
 
 // NewMemoryHandler creates a new memory handler
-func NewMemoryHandler(manager *memory.Manager) *MemoryHandler {
-	return &MemoryHandler{manager: manager}
+func NewMemoryHandler(manager *memory.Manager, logger zerolog.Logger) *MemoryHandler {
+	return &MemoryHandler{
+		manager: manager,
+		logger:  logger.With().Str("component", "memory-handler").Logger(),
+	}
 }
 
 // RegisterRoutes registers memory routes
@@ -35,6 +40,7 @@ func (h *MemoryHandler) handleCreate(c *fiber.Ctx) error {
 				"error": err.Error(),
 			})
 		}
+		h.logger.Info().Str("org_id", orgID).Int("count", len(results)).Msg("Batch memory create")
 		return c.Status(fiber.StatusCreated).JSON(fiber.Map{
 			"memories": results,
 			"count":    len(results),
@@ -52,6 +58,7 @@ func (h *MemoryHandler) handleCreate(c *fiber.Ctx) error {
 	mem, err := h.manager.Create(c.Context(), orgID, &req)
 	if err != nil {
 		if err == memory.ErrDuplicate {
+			h.logger.Debug().Str("org_id", orgID).Str("agent_id", req.AgentID).Msg("Duplicate memory rejected")
 			return c.Status(fiber.StatusConflict).JSON(fiber.Map{
 				"error": "duplicate memory",
 			})
@@ -60,6 +67,13 @@ func (h *MemoryHandler) handleCreate(c *fiber.Ctx) error {
 			"error": err.Error(),
 		})
 	}
+
+	h.logger.Info().
+		Str("org_id", orgID).
+		Str("agent_id", req.AgentID).
+		Str("memory_type", req.MemoryType).
+		Str("event_type", req.EventType).
+		Msg("Memory created")
 
 	return c.Status(fiber.StatusCreated).JSON(mem)
 }
@@ -86,6 +100,12 @@ func (h *MemoryHandler) handleList(c *fiber.Ctx) error {
 			"error": err.Error(),
 		})
 	}
+
+	h.logger.Info().
+		Str("org_id", orgID).
+		Str("agent_id", opts.AgentID).
+		Int("count", list.Count).
+		Msg("Memory list")
 
 	return c.JSON(list)
 }

--- a/internal/api/search_handler.go
+++ b/internal/api/search_handler.go
@@ -4,16 +4,21 @@ import (
 	"github.com/Basekick-Labs/memtrace/internal/auth"
 	"github.com/Basekick-Labs/memtrace/internal/memory"
 	"github.com/gofiber/fiber/v2"
+	"github.com/rs/zerolog"
 )
 
 // SearchHandler handles search endpoints
 type SearchHandler struct {
 	manager *memory.Manager
+	logger  zerolog.Logger
 }
 
 // NewSearchHandler creates a new search handler
-func NewSearchHandler(manager *memory.Manager) *SearchHandler {
-	return &SearchHandler{manager: manager}
+func NewSearchHandler(manager *memory.Manager, logger zerolog.Logger) *SearchHandler {
+	return &SearchHandler{
+		manager: manager,
+		logger:  logger.With().Str("component", "search-handler").Logger(),
+	}
 }
 
 // RegisterRoutes registers search routes
@@ -37,6 +42,12 @@ func (h *SearchHandler) handleSearch(c *fiber.Ctx) error {
 			"error": err.Error(),
 		})
 	}
+
+	h.logger.Info().
+		Str("org_id", orgID).
+		Str("agent_id", query.AgentID).
+		Int("count", result.Count).
+		Msg("Memory search")
 
 	return c.JSON(result)
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -47,7 +47,7 @@ func NewServer(
 	app.Use(func(c *fiber.Ctx) error {
 		start := time.Now()
 		err := c.Next()
-		logger.Debug().
+		logger.Info().
 			Str("method", c.Method()).
 			Str("path", c.Path()).
 			Int("status", c.Response().StatusCode()).
@@ -67,16 +67,16 @@ func NewServer(
 	}
 
 	// Register handlers
-	memoryHandler := NewMemoryHandler(memoryManager)
+	memoryHandler := NewMemoryHandler(memoryManager, logger)
 	memoryHandler.RegisterRoutes(apiGroup)
 
-	agentHandler := NewAgentHandler(agentManager, memoryManager)
+	agentHandler := NewAgentHandler(agentManager, memoryManager, logger)
 	agentHandler.RegisterRoutes(apiGroup)
 
-	sessionHandler := NewSessionHandler(sessionManager, memoryManager)
+	sessionHandler := NewSessionHandler(sessionManager, memoryManager, logger)
 	sessionHandler.RegisterRoutes(apiGroup)
 
-	searchHandler := NewSearchHandler(memoryManager)
+	searchHandler := NewSearchHandler(memoryManager, logger)
 	searchHandler.RegisterRoutes(apiGroup)
 
 	return &Server{

--- a/internal/api/session_handler.go
+++ b/internal/api/session_handler.go
@@ -5,19 +5,22 @@ import (
 	"github.com/Basekick-Labs/memtrace/internal/memory"
 	"github.com/Basekick-Labs/memtrace/internal/session"
 	"github.com/gofiber/fiber/v2"
+	"github.com/rs/zerolog"
 )
 
 // SessionHandler handles session endpoints
 type SessionHandler struct {
 	sessionManager *session.Manager
 	memoryManager  *memory.Manager
+	logger         zerolog.Logger
 }
 
 // NewSessionHandler creates a new session handler
-func NewSessionHandler(sessionManager *session.Manager, memoryManager *memory.Manager) *SessionHandler {
+func NewSessionHandler(sessionManager *session.Manager, memoryManager *memory.Manager, logger zerolog.Logger) *SessionHandler {
 	return &SessionHandler{
 		sessionManager: sessionManager,
 		memoryManager:  memoryManager,
+		logger:         logger.With().Str("component", "session-handler").Logger(),
 	}
 }
 
@@ -47,6 +50,8 @@ func (h *SessionHandler) handleCreate(c *fiber.Ctx) error {
 			"error": err.Error(),
 		})
 	}
+
+	h.logger.Info().Str("org_id", orgID).Str("session_id", s.ID).Str("agent_id", req.AgentID).Msg("Session created")
 
 	return c.Status(fiber.StatusCreated).JSON(s)
 }
@@ -150,6 +155,8 @@ func (h *SessionHandler) handleContext(c *fiber.Ctx) error {
 			"error": err.Error(),
 		})
 	}
+
+	h.logger.Info().Str("org_id", orgID).Str("session_id", sessionID).Int("memory_count", ctx.MemoryCount).Msg("Session context loaded")
 
 	return c.JSON(ctx)
 }


### PR DESCRIPTION
## Summary
- Promote request middleware log from `Debug` to `Info` level so all HTTP requests are visible at default log level
- Add `zerolog.Logger` with component loggers to all 4 handler structs (memory, agent, session, search)
- Log key operations at `Info` level: memory create/batch/list/search, agent register/delete, session create/context
- Log duplicate memory rejections at `Debug` level (expected control flow, not errors)

This addresses the issue from live testing where Memtrace logs were silent during multi-agent operation — only session creates were visible. Now every memory ingestion, query, and search is logged with org/agent context.

## What you'll see in logs now
```
INF request method=POST path=/api/v1/memories status=201 latency=12.3ms
INF Memory created org_id=org_abc agent_id=historian memory_type=episodic event_type=observation component=memory-handler
INF request method=GET path=/api/v1/memories status=200 latency=8.1ms
INF Memory list org_id=org_abc agent_id=historian count=5 component=memory-handler
INF request method=POST path=/api/v1/search status=200 latency=15.2ms
INF Memory search org_id=org_abc agent_id=forecaster count=12 component=search-handler
```

## Test plan
- [x] `go build ./cmd/... ./internal/... ./pkg/...` passes
- [ ] Start Memtrace, run Super Bowl demo — verify memory creates, queries, searches all log at INFO
- [ ] Set log level to `debug` — verify duplicate rejections are logged
- [ ] No sensitive data (API keys, memory content) in logs