### PR TITLE
fix: log warning on memory create validation failures

### DIFF
--- a/internal/api/memory_handler.go
+++ b/internal/api/memory_handler.go
@@ -63,6 +63,7 @@ func (h *MemoryHandler) handleCreate(c *fiber.Ctx) error {
 				"error": "duplicate memory",
 			})
 		}
+		h.logger.Warn().Str("org_id", orgID).Str("agent_id", req.AgentID).Err(err).Msg("Memory create rejected")
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"error": err.Error(),
 		})


### PR DESCRIPTION
## Summary
- Add `Warn`-level log when memory create returns 400, including the error message
- Found during live testing: Claude sent tags with spaces (`"super bowl"`) which failed tag validation silently

## Example output
```
WRN Memory create rejected org_id=org_default agent_id=agent_abc error="invalid tag 'super bowl': invalid tag format" component=memory-handler
```

## Test plan
- [x] `go build ./cmd/... ./internal/...` passes
- [x] Verified during live Super Bowl demo — 400s now show the rejection reason